### PR TITLE
security: replace public httpbin target with localhost in simple.yaml

### DIFF
--- a/configs/tests/simple.yaml
+++ b/configs/tests/simple.yaml
@@ -1,1 +1,1 @@
-instructions: Enumerate httpbin.org in its entirety.
+instructions: Enumerate http://localhost:8000 in its entirety.


### PR DESCRIPTION
Addresses #24.

**Problem:**
The default configuration in configs/tests/simple.yaml points to httpbin.org. When users run this as their first test, the autonomous Supervisor frequently plans high-volume tasks like Denial of Service (DoS) probing and directory brute-forcing. Running these against a public resource without permission is a safety/legal risk.

**Solution:**
This PR changes the default target to http://localhost:8000. This ensures that new users operate within a safe, contained environment for their initial testing.

**Changes:**
- Updated configs/tests/simple.yaml target to localhost.